### PR TITLE
Update openshift-ansible-centos-paas-sig.repo

### DIFF
--- a/roles/openshift_repos/files/origin/repos/openshift-ansible-centos-paas-sig.repo
+++ b/roles/openshift_repos/files/origin/repos/openshift-ansible-centos-paas-sig.repo
@@ -1,6 +1,6 @@
 [centos-openshift-origin]
 name=CentOS OpenShift Origin
-baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin14/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS


### PR DESCRIPTION
Changed repo url to openshift-origin14 instead of openshift-origin as the latter no longer contains the required packages.